### PR TITLE
Add dog enemies and detailed stone wall

### DIFF
--- a/script.js
+++ b/script.js
@@ -39,6 +39,7 @@ class NinjaGame {
         this.guards = [];
         this.cats = [];
         this.obstacles = [];
+        this.dogs = [];
         
         // コントロール
         this.keys = {
@@ -248,6 +249,7 @@ class NinjaGame {
         this.guards = [];
         this.cats = [];
         this.obstacles = [];
+        this.dogs = [];
         
         // 見張りの目を配置
         for (let i = 0; i < 10; i++) {
@@ -272,6 +274,18 @@ class NinjaGame {
                 height: 20,
                 sleepTime: Math.random() * 3000 + 2000,
                 awakeBehavior: Math.random() > 0.5
+            });
+        }
+
+        // 犬を配置
+        for (let i = 0; i < 4; i++) {
+            this.dogs.push({
+                x: Math.random() * (this.canvasWidth - 40),
+                y: -180 - (i * 300),
+                width: 40,
+                height: 25,
+                direction: Math.random() > 0.5 ? 1 : -1,
+                speed: 1 + Math.random()
             });
         }
         
@@ -326,6 +340,7 @@ class NinjaGame {
         // 敵の更新
         this.updateGuards(deltaTime);
         this.updateCats(deltaTime);
+        this.updateDogs(deltaTime);
         
         // 衝突判定
         this.checkCollisions();
@@ -394,6 +409,27 @@ class NinjaGame {
             }
         });
     }
+
+    updateDogs(deltaTime) {
+        this.dogs.forEach(dog => {
+            dog.x += dog.direction * dog.speed;
+
+            if (dog.x <= 0 || dog.x >= this.canvasWidth - dog.width) {
+                dog.direction *= -1;
+            }
+
+            const dogScreenY = dog.y + this.scrollY;
+            if (
+                this.ninja.x < dog.x + dog.width &&
+                this.ninja.x + this.ninja.width > dog.x &&
+                this.ninja.y < dogScreenY + dog.height &&
+                this.ninja.y + this.ninja.height > dogScreenY &&
+                !this.ninja.hiding
+            ) {
+                this.gameOver();
+            }
+        });
+    }
     
     checkCollisions() {
         // 障害物との衝突（足場として使用）
@@ -427,6 +463,7 @@ class NinjaGame {
         // 敵
         this.drawGuards();
         this.drawCats();
+        this.drawDogs();
         
         // 忍者
         this.drawNinja();
@@ -520,6 +557,30 @@ class NinjaGame {
                 // 尻尾
                 this.ctx.fillStyle = '#444';
                 this.ctx.fillRect(cat.x + cat.width, y + 5, 8, 3);
+            }
+        });
+    }
+
+    drawDogs() {
+        this.dogs.forEach(dog => {
+            const y = dog.y + this.scrollY;
+            if (y > -50 && y < this.canvasHeight + 50) {
+                // 体
+                this.ctx.fillStyle = '#a0522d';
+                this.ctx.fillRect(dog.x, y, dog.width, dog.height);
+
+                // 頭
+                this.ctx.fillRect(dog.x + dog.width - 15, y - 10, 15, 10);
+
+                // 耳
+                this.ctx.fillStyle = '#8b4513';
+                this.ctx.fillRect(dog.x + dog.width - 15, y - 14, 5, 4);
+                this.ctx.fillRect(dog.x + dog.width - 5, y - 14, 5, 4);
+
+                // 目
+                this.ctx.fillStyle = '#000';
+                this.ctx.fillRect(dog.x + dog.width - 12, y - 8, 2, 2);
+                this.ctx.fillRect(dog.x + dog.width - 6, y - 8, 2, 2);
             }
         });
     }

--- a/stone-wall.svg
+++ b/stone-wall.svg
@@ -1,17 +1,38 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
-  <rect width="200" height="200" fill="#777"/>
-  <polygon points="0,0 80,0 75,70 0,70" fill="#8f8f8f"/>
-  <polygon points="80,0 200,0 200,70 75,70" fill="#999"/>
-  <polygon points="0,70 110,70 100,130 0,130" fill="#9f9f9f"/>
-  <polygon points="110,70 200,70 200,130 100,130" fill="#b0b0b0"/>
-  <polygon points="0,130 90,130 85,200 0,200" fill="#a1a1a1"/>
-  <polygon points="90,130 200,130 200,200 85,200" fill="#8a8a8a"/>
-  <g stroke="#555" stroke-width="4" fill="none">
-    <polygon points="0,0 80,0 75,70 0,70"/>
-    <polygon points="80,0 200,0 200,70 75,70"/>
-    <polygon points="0,70 110,70 100,130 0,130"/>
-    <polygon points="110,70 200,70 200,130 100,130"/>
-    <polygon points="0,130 90,130 85,200 0,200"/>
-    <polygon points="90,130 200,130 200,200 85,200"/>
+  <rect width="200" height="200" fill="#666"/>
+  <g>
+    <rect x="0" y="0" width="40" height="40" fill="#7a7a7a" stroke="#555" stroke-width="2"/>
+    <rect x="40" y="0" width="40" height="40" fill="#808080" stroke="#555" stroke-width="2"/>
+    <rect x="80" y="0" width="40" height="40" fill="#858585" stroke="#555" stroke-width="2"/>
+    <rect x="120" y="0" width="40" height="40" fill="#7f7f7f" stroke="#555" stroke-width="2"/>
+    <rect x="160" y="0" width="40" height="40" fill="#8a8a8a" stroke="#555" stroke-width="2"/>
+
+    <rect x="0" y="40" width="40" height="40" fill="#808080" stroke="#555" stroke-width="2"/>
+    <rect x="40" y="40" width="40" height="40" fill="#8f8f8f" stroke="#555" stroke-width="2"/>
+    <rect x="80" y="40" width="40" height="40" fill="#828282" stroke="#555" stroke-width="2"/>
+    <rect x="120" y="40" width="40" height="40" fill="#8c8c8c" stroke="#555" stroke-width="2"/>
+    <rect x="160" y="40" width="40" height="40" fill="#858585" stroke="#555" stroke-width="2"/>
+
+    <rect x="0" y="80" width="40" height="40" fill="#888888" stroke="#555" stroke-width="2"/>
+    <rect x="40" y="80" width="40" height="40" fill="#939393" stroke="#555" stroke-width="2"/>
+    <rect x="80" y="80" width="40" height="40" fill="#8b8b8b" stroke="#555" stroke-width="2"/>
+    <rect x="120" y="80" width="40" height="40" fill="#949494" stroke="#555" stroke-width="2"/>
+    <rect x="160" y="80" width="40" height="40" fill="#8d8d8d" stroke="#555" stroke-width="2"/>
+
+    <rect x="0" y="120" width="40" height="40" fill="#7e7e7e" stroke="#555" stroke-width="2"/>
+    <rect x="40" y="120" width="40" height="40" fill="#878787" stroke="#555" stroke-width="2"/>
+    <rect x="80" y="120" width="40" height="40" fill="#808080" stroke="#555" stroke-width="2"/>
+    <rect x="120" y="120" width="40" height="40" fill="#8a8a8a" stroke="#555" stroke-width="2"/>
+    <rect x="160" y="120" width="40" height="40" fill="#7f7f7f" stroke="#555" stroke-width="2"/>
+
+    <rect x="0" y="160" width="40" height="40" fill="#8a8a8a" stroke="#555" stroke-width="2"/>
+    <rect x="40" y="160" width="40" height="40" fill="#929292" stroke="#555" stroke-width="2"/>
+    <rect x="80" y="160" width="40" height="40" fill="#8b8b8b" stroke="#555" stroke-width="2"/>
+    <rect x="120" y="160" width="40" height="40" fill="#939393" stroke="#555" stroke-width="2"/>
+    <rect x="160" y="160" width="40" height="40" fill="#858585" stroke="#555" stroke-width="2"/>
+  </g>
+  <g stroke="#444" stroke-width="1" fill="none">
+    <path d="M10 60 l15 -10 l5 20"/>
+    <path d="M150 120 l20 10 l-10 15"/>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- Add roaming dog enemies with collision detection
- Replace stone wall background with detailed brick pattern

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689066c875cc8330b3962194d758e0fd