### PR TITLE
Add background music using audio assets

### DIFF
--- a/script.js
+++ b/script.js
@@ -53,7 +53,11 @@ class NinjaGame {
         // アニメーション
         this.animationId = 0;
         this.lastTime = 0;
-        
+
+        // BGM設定
+        this.bgm = new Audio('audio/nekugi.mp3');
+        this.bgm.loop = true;
+
         this.init();
     }
     
@@ -240,7 +244,13 @@ class NinjaGame {
         
         // 敵・障害物生成
         this.generateLevel();
-        
+
+        // BGM再生
+        if (this.bgm) {
+            this.bgm.currentTime = 0;
+            this.bgm.play();
+        }
+
         // ゲームループ開始
         this.gameLoop();
     }
@@ -659,6 +669,10 @@ class NinjaGame {
     }
     
     gameClear() {
+        // BGM停止
+        if (this.bgm) {
+            this.bgm.pause();
+        }
         this.gameState = 'clear';
         cancelAnimationFrame(this.animationId);
         
@@ -686,6 +700,10 @@ class NinjaGame {
     }
     
     gameOver() {
+        // BGM停止
+        if (this.bgm) {
+            this.bgm.pause();
+        }
         this.gameState = 'gameover';
         cancelAnimationFrame(this.animationId);
         


### PR DESCRIPTION
## Summary
- play `audio/nekugi.mp3` as looping background music when gameplay starts
- pause the background track on game clear or game over

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68908120dfb88330a8433515d7ac8648