### PR TITLE
style: enhance mobile UI controls and HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,9 +28,9 @@
         <!-- ゲーム画面 -->
         <div id="gameScreen" style="display: none;">
             <div id="gameInfo">
-                <div id="score">忍度: 0点</div>
-                <div id="stage">階: 1F</div>
-                <div id="stealth">隠密度: 100%</div>
+                <div class="info-item"><span class="icon">🥷</span><span id="score">0</span></div>
+                <div class="info-item"><span class="icon">🪜</span><span id="stage">1F</span></div>
+                <div class="info-item"><span class="icon">👁️</span><span id="stealth">100%</span></div>
             </div>
             
             <canvas id="gameCanvas"></canvas>
@@ -43,7 +43,7 @@
                     <button id="downBtn" class="control-btn">↓</button>
                     <button id="rightBtn" class="control-btn">→</button>
                 </div>
-                <button id="hideBtn" class="control-btn hide-btn">隠</button>
+                <button id="hideBtn" class="control-btn hide-btn" title="しゃがむ / 隠れる"><span class="hide-icon">🧎</span>隠</button>
             </div>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -740,9 +740,9 @@ class NinjaGame {
     }
     
     updateUI() {
-        document.getElementById('score').textContent = `忍度: ${this.score}点`;
-        document.getElementById('stage').textContent = `階: ${this.stage}F`;
-        document.getElementById('stealth').textContent = `隠密度: ${Math.round(this.stealthLevel)}%`;
+        document.getElementById('score').textContent = `${this.score}`;
+        document.getElementById('stage').textContent = `${this.stage}F`;
+        document.getElementById('stealth').textContent = `${Math.round(this.stealthLevel)}%`;
         
         // ステルス度による色変更
         const stealthElement = document.getElementById('stealth');

--- a/style.css
+++ b/style.css
@@ -111,21 +111,28 @@ body {
 #gameInfo {
   position: absolute;
   top: 10px;
-  left: 10px;
-  right: 10px;
+  left: 50%;
+  transform: translateX(-50%);
   display: flex;
-  justify-content: space-between;
+  gap: 10px;
   z-index: 1000;
   font-size: clamp(0.8rem, 3vw, 1.2rem);
   font-weight: bold;
   text-shadow: 2px 2px 4px #000;
 }
 
-#gameInfo div {
+#gameInfo .info-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   background: rgba(0,0,0,0.7);
   padding: 8px 12px;
   border-radius: 15px;
   border: 2px solid #ffd700;
+}
+
+#gameInfo .icon {
+  font-size: 1.2em;
 }
 
 #gameCanvas {
@@ -147,10 +154,10 @@ body {
   padding: 0 20px;
   gap: 20px;
   z-index: 1000;
-  transform: scale(0.7);
+  transform: scale(0.8);
   transform-origin: bottom center;
   /* ボタンのサイズを変えるときはこの変数だけを調整 */
-  --btn-size: 78px;
+  --btn-size: 90px;
 }
 
 #directionControls {
@@ -222,8 +229,8 @@ body {
 #directionControls .control-btn {
   width: var(--btn-size);
   height: var(--btn-size);
-  border: none;
-  background: none;
+  border: 2px solid rgba(255, 215, 0, 0.8);
+  background: rgba(0,0,0,0.3);
   color: #ffd700;
   font-size: 2rem;
   font-weight: bold;
@@ -231,13 +238,15 @@ body {
   cursor: pointer;
   user-select: none;
   touch-action: manipulation;
-  transition: background 0.2s ease;
-  border-radius: 0;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+  border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.6);
   z-index: 1;
 }
 
 #directionControls .control-btn:active {
-  background: rgba(255, 215, 0, 0.2);
+  background: rgba(255, 215, 0, 0.3);
+  box-shadow: 0 0 10px rgba(255,215,0,0.8);
 }
 
 #leftBtn,
@@ -258,11 +267,11 @@ body {
   background: radial-gradient(circle at 30% 30%, #ff4d4d, #b30000);
   color: #fff;
   font-size: 2.2rem;
-  box-shadow: 0 4px 15px rgba(255, 0, 0, 0.6);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.6);
   cursor: pointer;
   user-select: none;
   touch-action: manipulation;
-  transition: transform 0.2s ease, background 0.2s ease;
+  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -271,6 +280,11 @@ body {
 .hide-btn:active {
   background: radial-gradient(circle at 30% 30%, #ff6b6b, #ff0000);
   transform: scale(1.1);
+  box-shadow: 0 0 15px rgba(255,0,0,0.8);
+}
+
+.hide-btn .hide-icon {
+  margin-right: 4px;
 }
 
 /* クリア画面 */
@@ -356,11 +370,11 @@ body {
   #gameInfo {
       font-size: 0.9rem;
   }
-  
-  #gameInfo div {
+
+  #gameInfo .info-item {
       padding: 6px 10px;
   }
-  
+
   #directionControls .control-btn {
       font-size: 1.56rem;
   }
@@ -374,7 +388,7 @@ body {
       padding: 0 15px;
       justify-content: center;
       gap: 15px;
-      --btn-size: 65px;
+      --btn-size: 75px;
   }
 }
 
@@ -409,6 +423,6 @@ body {
   }
   
   #mobileControls {
-      --btn-size: 85px;
+      --btn-size: 100px;
   }
 }


### PR DESCRIPTION
## Summary
- consolidate HUD metrics into a centered icon-based info bar
- enlarge and restyle mobile control pad with borders, shadows, and press feedback
- add crouch icon and tooltip to hide button

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893419e407c833082b9c0bd26b45653