### PR TITLE
Add external controller UI

### DIFF
--- a/controller-wrapper.html
+++ b/controller-wrapper.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Ninja Stealth Controller</title>
+<style>
+  html,body{margin:0;padding:0;height:100%;display:flex;flex-direction:column;}
+  #game-frame{flex:1;border:none;width:100%;}
+  #controls{display:flex;justify-content:space-around;padding:10px;background:#222;}
+  #controls button{flex:1;margin:0 5px;padding:15px 0;font-size:2rem;border:none;border-radius:8px;background:#444;color:#fff;}
+</style>
+</head>
+<body>
+<iframe id="game-frame" src="index.html"></iframe>
+<div id="controls">
+  <button data-code="ArrowLeft">←</button>
+  <button data-code="ArrowRight">→</button>
+  <button data-code="KeyF">□</button>
+  <button data-code="ArrowUp">↑</button>
+</div>
+<script>
+const frame=document.getElementById('game-frame').contentWindow;
+const buttons=document.querySelectorAll('#controls button');
+buttons.forEach(btn=>{
+  const code=btn.dataset.code;
+  const send=pressed=>frame.postMessage({type:'control',code,pressed},'*');
+  btn.addEventListener('mousedown',()=>send(true));
+  btn.addEventListener('mouseup',()=>send(false));
+  btn.addEventListener('mouseleave',()=>send(false));
+  btn.addEventListener('touchstart',e=>{e.preventDefault();send(true);});
+  btn.addEventListener('touchend',e=>{e.preventDefault();send(false);});
+  btn.addEventListener('touchcancel',e=>{e.preventDefault();send(false);});
+});
+</script>
+</body>
+</html>

--- a/stealth.js
+++ b/stealth.js
@@ -77,6 +77,14 @@ document.addEventListener('keydown',e=>{
 });
 document.addEventListener('keyup',e=>{keys[e.code]=false;});
 
+// allow control via postMessage from an external controller
+window.addEventListener('message',e=>{
+  const data=e.data;
+  if(!data||data.type!=='control')return;
+  keys[data.code]=data.pressed;
+  if(data.code==='KeyF'&&data.pressed)throwStone();
+});
+
 function throwStone(){
   const dir=player.facing; 
   stones.push({x:player.x+player.w/2,y:player.y+player.h/2,vx:dir.x*4,vy:dir.y*4,life:60});


### PR DESCRIPTION
## Summary
- Allow game to receive control messages via `postMessage`
- Provide `controller-wrapper.html` with four large buttons that send control commands to the embedded game

## Testing
- `node --check stealth.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689487630d788330b7f7079b705b8605