### PR TITLE
Fix canvas not resizing when starting game

### DIFF
--- a/script.js
+++ b/script.js
@@ -148,7 +148,8 @@ function handleKeyUp(e) {
 function startGame() {
     document.getElementById('title-screen').style.display = 'none';
     document.getElementById('game-screen').style.display = 'block';
-    
+    resizeCanvas();
+
     gameState.screen = 'playing';
     gameState.score = 0;
     gameState.life = 3;


### PR DESCRIPTION
## Summary
- Ensure game canvas is resized after showing the game screen

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689491c67a108330a2466082a60e0ec2