### PR TITLE
Add stage-specific SVG enemies

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,21 @@
             <line x1="5" y1="10" x2="5" y2="20" stroke="#333333"/>
         </svg>
 
+        <!-- 槍兵 -->
+        <svg id="spearman-svg" width="45" height="45" viewBox="0 0 45 45">
+            <rect x="14" y="20" width="17" height="18" fill="#228b22" rx="2"/>
+            <circle cx="22.5" cy="15" r="7" fill="#ffdbab"/>
+            <line x1="35" y1="15" x2="45" y2="5" stroke="#8b4513" stroke-width="2"/>
+            <line x1="45" y1="5" x2="45" y2="25" stroke="#c0c0c0" stroke-width="2"/>
+        </svg>
+
+        <!-- 盾兵 -->
+        <svg id="shieldman-svg" width="45" height="45" viewBox="0 0 45 45">
+            <rect x="14" y="20" width="17" height="18" fill="#555555" rx="2"/>
+            <circle cx="22.5" cy="15" r="7" fill="#ffdbab"/>
+            <path d="M35 20 A8 8 0 0 1 35 36 A8 8 0 0 1 35 20" fill="#999999"/>
+        </svg>
+
         <!-- 殿 -->
         <svg id="lord-svg" width="80" height="60" viewBox="0 0 80 60">
             <ellipse cx="40" cy="45" rx="35" ry="12" fill="#6b46c1"/>


### PR DESCRIPTION
## Summary
- spawn enemies per floor and introduce new types each stage
- add spearman and shieldman SVG enemies with canvas rendering
- render and patrol logic updated for new enemy types

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689567d67f5883309d2927e9a2351909