### PR TITLE
Add background music playback

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,6 +125,8 @@
         </svg>
     </div>
 
+    <audio id="bgm" src="audio/nekugi.mp3" loop></audio>
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -14,6 +14,7 @@ let canvas;
 let ctx;
 let canvasWidth = 400;
 let canvasHeight = 600;
+let bgm;
 
 // プレイヤー（忍者）
 const player = {
@@ -160,7 +161,10 @@ function startGame() {
     gameState.life = 3;
     gameState.currentFloor = 1;
     gameState.scrollY = 0;
-    
+
+    bgm.currentTime = 0;
+    bgm.play();
+
     resetPlayer();
     enemies = [];
     projectiles = [];
@@ -177,12 +181,15 @@ function restartGame() {
     document.getElementById('clear-screen').style.display = 'none';
     document.getElementById('title-screen').style.display = 'block';
     document.getElementById('game-screen').style.display = 'none';
-    
+
     gameState.screen = 'title';
     enemies = [];
     projectiles = [];
     enemyProjectiles = [];
     spawnedFloors = new Set();
+
+    bgm.pause();
+    bgm.currentTime = 0;
 }
 
 // プレイヤーリセット
@@ -839,6 +846,8 @@ function drawEffects() {
 
 // ページ読み込み時の初期化
 document.addEventListener('DOMContentLoaded', function() {
+    bgm = document.getElementById('bgm');
+
     // モバイルデバイスの判定
     const isMobile = /Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
     


### PR DESCRIPTION
## Summary
- embed looping audio element for the game's background music
- start and stop BGM via JavaScript when game begins and returns to title

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896f1272fdc8330a6feab31809554f3