### PR TITLE
Enable automatic background music

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
         </svg>
     </div>
 
-    <audio id="bgm" src="audio/nekugi.mp3" loop></audio>
+    <audio id="bgm" src="audio/nekugi.mp3" loop autoplay></audio>
 
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -848,6 +848,13 @@ function drawEffects() {
 document.addEventListener('DOMContentLoaded', function() {
     bgm = document.getElementById('bgm');
 
+    // ユーザーが操作したタイミングでBGMを再生
+    const enableBgm = () => {
+        bgm.play().catch(() => {});
+    };
+    document.addEventListener('pointerdown', enableBgm, { once: true });
+    document.addEventListener('keydown', enableBgm, { once: true });
+
     // モバイルデバイスの判定
     const isMobile = /Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
     


### PR DESCRIPTION
## Summary
- Start background music automatically on page load and ensure playback after user interaction.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897375f1858833098d62eca38548cdb