### PR TITLE
Enable snore sound after user interaction

### DIFF
--- a/stealth.js
+++ b/stealth.js
@@ -32,7 +32,14 @@ function init(){
   canvas.width=width;canvas.height=height;
   ctx=canvas.getContext('2d');
   parseMap();
-  startSnore();
+  // Start snoring sound after the player interacts with the page
+  const enableSound = () => {
+    startSnore();
+    window.removeEventListener('pointerdown', enableSound);
+    window.removeEventListener('keydown', enableSound);
+  };
+  window.addEventListener('pointerdown', enableSound, { once: true });
+  window.addEventListener('keydown', enableSound, { once: true });
   loop();
 }
 


### PR DESCRIPTION
## Summary
- start snoring ambient audio only after user input so browsers allow playback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ea743b63483308f29a264ff9e9494